### PR TITLE
Feat: Add Widget to `add_todos` Action

### DIFF
--- a/skills/productivity/todo_list/src/actions/add_todos.py
+++ b/skills/productivity/todo_list/src/actions/add_todos.py
@@ -46,5 +46,12 @@ def run(params: ActionParams) -> None:
         'data': {
             'list': list_name,
             'result': result
-        }
+        },
+        'widget': TodosListWidget(WidgetOptions(
+            id=widget_id,
+            params={
+                'list_name': list_name,
+                'todos': memory.get_todo_items(list_name)
+            }
+        ))
     })


### PR DESCRIPTION
This PR enhances the `add_todos` action by displaying the updated todo list as a widget immediately after adding new items. The `add_todos` action now fetches the updated list, creates a `TodosListWidget` with the new data, and includes it in the response.